### PR TITLE
Revert "Update ibm_catalog.json - remove dependencies section"

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -452,6 +452,17 @@
               ]
             }
           ],
+          "dependencies": [
+            {
+              "flavors": [
+                "quickstart",
+                "standard"
+              ],
+              "id": "95fccffc-ae3b-42df-b6d9-80be5914d852-global",
+              "name": "deploy-arch-ibm-slz-ocp",
+              "version": ">=v3.0.0"
+            }
+          ],
           "architecture": {
             "descriptions": "This architecture supports the deployment of IBM Log Analysis and IBM Cloud Monitoring agents on an existing Red Hat OpenShift cluster on a secure landing zone.",
             "features": [


### PR DESCRIPTION
Reverts terraform-ibm-modules/terraform-ibm-observability-da#119

so it seems I can’t mark a version as ready if its an extension type with adding a dependencies section:
![image](https://github.com/terraform-ibm-modules/terraform-ibm-scc-da/assets/29608224/60bf3cb9-0925-4727-987d-631e39e039d5)