### PR TITLE
fix: add suport for wait_till cluster is ready

### DIFF
--- a/solutions/agents/main.tf
+++ b/solutions/agents/main.tf
@@ -3,7 +3,7 @@
 ##############################################################################
 
 data "ibm_container_cluster_config" "cluster_config" {
-  cluster_name_id   = var.cluster_id
+  cluster_name_id   = var.is_vpc_cluster ? data.ibm_container_vpc_cluster.cluster[0].name : data.ibm_container_cluster.cluster[0].name
   resource_group_id = var.cluster_resource_group_id
   config_dir        = "${path.module}/kubeconfig"
   endpoint_type     = var.cluster_config_endpoint_type != "default" ? var.cluster_config_endpoint_type : null

--- a/solutions/agents/provider.tf
+++ b/solutions/agents/provider.tf
@@ -13,3 +13,19 @@ provider "helm" {
     token = data.ibm_container_cluster_config.cluster_config.token
   }
 }
+
+# Retrieve information about an existing VPC cluster
+data "ibm_container_vpc_cluster" "cluster" {
+  count             = var.is_vpc_cluster ? 1 : 0
+  name              = var.cluster_id
+  wait_till         = var.wait_till
+  wait_till_timeout = var.wait_till_timeout
+}
+
+# Retrieve information about an existing Classic cluster
+data "ibm_container_cluster" "cluster" {
+  count             = var.is_vpc_cluster ? 0 : 1
+  name              = var.cluster_id
+  wait_till         = var.wait_till
+  wait_till_timeout = var.wait_till_timeout
+}

--- a/solutions/agents/variables.tf
+++ b/solutions/agents/variables.tf
@@ -60,7 +60,7 @@ variable "wait_till" {
 variable "wait_till_timeout" {
   description = "Timeout for wait_till in minutes."
   type        = number
-  default     = 30
+  default     = 90
 }
 
 ##############################################################################

--- a/solutions/agents/variables.tf
+++ b/solutions/agents/variables.tf
@@ -35,6 +35,34 @@ variable "cluster_config_endpoint_type" {
   }
 }
 
+variable "is_vpc_cluster" {
+  type        = bool
+  description = "Specify true if the target cluster for the DA is a VPC cluster, false if it is classic cluster."
+  default     = true
+}
+
+variable "wait_till" {
+  description = "To avoid long wait times when you run your Terraform code, you can specify the stage when you want Terraform to mark the cluster resource creation as completed. Depending on what stage you choose, the cluster creation might not be fully completed and continues to run in the background. However, your Terraform code can continue to run without waiting for the cluster to be fully created. Supported args are `MasterNodeReady`, `OneWorkerNodeReady`, `IngressReady` and `Normal`"
+  type        = string
+  default     = "Normal"
+
+  validation {
+    error_message = "`wait_till` value must be one of `MasterNodeReady`, `OneWorkerNodeReady`, `IngressReady` or `Normal`."
+    condition = contains([
+      "MasterNodeReady",
+      "OneWorkerNodeReady",
+      "IngressReady",
+      "Normal"
+    ], var.wait_till)
+  }
+}
+
+variable "wait_till_timeout" {
+  description = "Timeout for wait_till in minutes."
+  type        = number
+  default     = 30
+}
+
 ##############################################################################
 # Log Analysis variables
 ##############################################################################


### PR DESCRIPTION
### Description

This PR adds following:
- Adds support to wait on cluster creation for IKS/ROKS classic
- Adds new variable is_vpc_cluster (by default true) to differentiate between Classic and VPC


<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Issue
https://github.ibm.com/GoldenEye/issues/issues/10708

### Release required?

<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Adds support to wait on cluster creation before deploying observability agents

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
