### PR TITLE
fix: update to latest agents module

### DIFF
--- a/solutions/agents/main.tf
+++ b/solutions/agents/main.tf
@@ -11,10 +11,12 @@ data "ibm_container_cluster_config" "cluster_config" {
 
 module "observability_agents" {
   source                       = "terraform-ibm-modules/observability-agents/ibm"
-  version                      = "2.1.0"
+  version                      = "2.3.1"
   cluster_id                   = var.cluster_id
   cluster_resource_group_id    = var.cluster_resource_group_id
   cluster_config_endpoint_type = var.cluster_config_endpoint_type
+  wait_till_timeout            = var.wait_till_timeout
+  wait_till                    = var.wait_till
   # Cloud Monitoring (Sysdig) Agent
   cloud_monitoring_enabled           = var.cloud_monitoring_enabled
   cloud_monitoring_agent_name        = var.prefix != null ? "${var.prefix}-${var.cloud_monitoring_agent_name}" : var.cloud_monitoring_agent_name

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -29,17 +29,18 @@ const solutionAgentsDADir = "solutions/agents"
 const agentsKubeconfigDir = "solutions/agents/kubeconfig"
 
 // Current supported regions for Observability instances
+// (NOTE: Disabling some regions temporarily due to known issue in those regions)
 var validRegions = []string{
 	"au-syd",
-	"eu-de",
-	"eu-es",
 	"eu-gb",
-	"jp-osa",
-	"jp-tok",
-	"us-south",
-	"us-east",
-	"ca-tor",
-	"br-sao",
+	// "eu-de",
+	// "eu-es",
+	// "jp-osa",
+	// "jp-tok",
+	// "us-south",
+	// "us-east",
+	// "ca-tor",
+	// "br-sao",
 }
 
 var sharedInfoSvc *cloudinfo.CloudInfoService

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -102,10 +102,12 @@ func TestInstancesInSchematics(t *testing.T) {
 func TestRunUpgradeSolutionInstances(t *testing.T) {
 	t.Parallel()
 
+	var region = validRegions[rand.Intn(len(validRegions))]
+
 	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
 		Testing:      t,
 		TerraformDir: solutionInstanceDADir,
-		Region:       "us-south",
+		Region:       region,
 		Prefix:       "obs-ins-upg",
 	})
 
@@ -230,7 +232,8 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 	realTerraformDir := "./resources/existing-resources"
 	tempTerraformDir, _ := files.CopyTerraformFolderToTemp(realTerraformDir, fmt.Sprintf(prefix+"-%s", strings.ToLower(random.UniqueId())))
 	tags := common.GetTagsFromTravis()
-	region := "us-south"
+
+	var region = validRegions[rand.Intn(len(validRegions))]
 
 	// Verify ibmcloud_api_key variable is set
 	checkVariable := "TF_VAR_ibmcloud_api_key"


### PR DESCRIPTION
### Description

update to latest agents module:
- contains fix for https://github.com/terraform-ibm-modules/terraform-ibm-observability-da/issues/212
- update sysdig agent to v13.5.0
- update logs agent to 1.3.3
- updated tests to only run in regions with backend fix for cloud logs

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
