### PR TITLE
feat:exposed visibility value for the provider in the DA

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -7,3 +7,4 @@ CRA_TARGETS:
     CRA_ENVIRONMENT_VARIABLES:
       TF_VAR_resource_group_name: "test"
       TF_VAR_existing_kms_instance_crn: "crn:v1:bluemix:public:hs-crypto:us-south:a/abac0df06b644a9cabc6e44f55b3880e:e6dce284-e80f-46e1-a3c1-830f7adff7a9::"
+      TF_VAR_provider_visibility: "public"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -107,6 +107,23 @@
               "key": "ibmcloud_api_key"
             },
             {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
+            },
+            {
               "key": "prefix"
             },
             {
@@ -505,6 +522,23 @@
           "configuration": [
             {
               "key": "ibmcloud_api_key"
+            },
+            {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
             },
             {
               "key": "prefix"

--- a/solutions/agents/provider.tf
+++ b/solutions/agents/provider.tf
@@ -1,5 +1,6 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
+  visibility       = var.provider_visibility
 }
 
 provider "kubernetes" {

--- a/solutions/agents/variables.tf
+++ b/solutions/agents/variables.tf
@@ -9,7 +9,16 @@ variable "prefix" {
   description = "The prefix for resources created by this solution."
   default     = null
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
 
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 ##############################################################################
 # Cluster variables
 ##############################################################################

--- a/solutions/instances/provider.tf
+++ b/solutions/instances/provider.tf
@@ -5,12 +5,14 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
+  visibility       = var.provider_visibility
 }
 
 provider "ibm" {
   alias            = "cos"
   ibmcloud_api_key = var.ibmcloud_cos_api_key != null ? var.ibmcloud_cos_api_key : var.ibmcloud_api_key
   region           = local.default_cos_region
+  visibility       = var.provider_visibility
 }
 
 
@@ -18,4 +20,5 @@ provider "ibm" {
   alias            = "kms"
   ibmcloud_api_key = var.ibmcloud_kms_api_key != null ? var.ibmcloud_kms_api_key : var.ibmcloud_api_key
   region           = local.kms_region
+  visibility       = var.provider_visibility
 }

--- a/solutions/instances/variables.tf
+++ b/solutions/instances/variables.tf
@@ -50,7 +50,16 @@ variable "prefix" {
   description = "The prefix to add to all resources that this solution creates."
   default     = null
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
 
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 ##############################################################################
 # IBM Cloud Logs
 ##############################################################################

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -197,7 +197,6 @@ func TestAgentsSolutionInSchematics(t *testing.T) {
 		options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 			{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 			{Name: "cloud_monitoring_instance_region", Value: region, DataType: "string"},
-			{Name: "provider_visibility", Value: "public", DataType: "string"},
 			{Name: "cluster_id", Value: terraform.Output(t, existingTerraformOptions, "workload_cluster_id"), DataType: "string"},
 			{Name: "logs_agent_trusted_profile", Value: terraform.Output(t, existingTerraformOptions, "trusted_profile_id"), DataType: "string"},
 			{Name: "cloud_logs_ingress_endpoint", Value: terraform.Output(t, existingTerraformOptions, "cloud_logs_ingress_private_endpoint"), DataType: "string"},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -117,6 +117,7 @@ func TestRunUpgradeSolutionInstances(t *testing.T) {
 		"cos_instance_access_tags":            permanentResources["accessTags"],
 		"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 		"kms_endpoint_type":                   "public",
+		"provider_visibility":                 "public",
 		"management_endpoint_type_for_bucket": "public",
 		"enable_platform_logs":                "false",
 		"enable_platform_metrics":             "false",
@@ -196,6 +197,7 @@ func TestAgentsSolutionInSchematics(t *testing.T) {
 		options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 			{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 			{Name: "cloud_monitoring_instance_region", Value: region, DataType: "string"},
+			{Name: "provider_visibility", Value: "public", DataType: "string"},
 			{Name: "cluster_id", Value: terraform.Output(t, existingTerraformOptions, "workload_cluster_id"), DataType: "string"},
 			{Name: "logs_agent_trusted_profile", Value: terraform.Output(t, existingTerraformOptions, "trusted_profile_id"), DataType: "string"},
 			{Name: "cloud_logs_ingress_endpoint", Value: terraform.Output(t, existingTerraformOptions, "cloud_logs_ingress_private_endpoint"), DataType: "string"},
@@ -290,6 +292,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 					},
 				},
 				"management_endpoint_type_for_bucket": "public",
+				"provider_visibility":                 "public",
 				"enable_platform_metrics":             "false",
 				"enable_platform_logs":                "false",
 				"cloud_logs_policies": []map[string]interface{}{
@@ -327,6 +330,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 				"existing_cos_kms_key_crn":            permanentResources["hpcs_south_root_key_crn"],
 				"kms_endpoint_type":                   "public",
+				"provider_visibility":                 "public",
 				"existing_cos_instance_crn":           terraform.Output(t, existingTerraformOptions, "cos_crn"),
 				"management_endpoint_type_for_bucket": "public",
 				"enable_platform_metrics":             "false",


### PR DESCRIPTION
### Description

exposed [visibility](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#visibility) value for the provider in the DAs , with default value set to "private"

[Git issue](https://github.ibm.com/GoldenEye/issues/issues/11335)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Exposed the ability to set the provider_visibility in the DAs. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/IBM/latest/docs#visibility-1)

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
