### PR TITLE
add workaround for catalog validation issue with cluster RBAC

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -15,8 +15,8 @@ offerings:
       - name: agents
         mark_ready: true
         install_type: extension
-        pre_validation: "tests/scripts/pre-validation-deploy-slz-roks-and-obs-instances.sh"
-        post_validation: "tests/scripts/post-validation-destroy-slz-roks-and-obs-instances.sh"
+        pre_validation: "tests/scripts/pre-validation-deploy-ocp-and-obs-instances.sh"
+        post_validation: "tests/scripts/post-validation-destroy-ocp-and-obs-instances.sh"
       - name: logs-routing
         mark_ready: true
         install_type: fullstack

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -209,10 +209,10 @@ func TestAgentsSolutionInSchematics(t *testing.T) {
 		options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 			{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 			{Name: "cloud_monitoring_instance_region", Value: region, DataType: "string"},
-			{Name: "cluster_id", Value: terraform.Output(t, existingTerraformOptions, "workload_cluster_id"), DataType: "string"},
+			{Name: "cluster_id", Value: terraform.Output(t, existingTerraformOptions, "cluster_id"), DataType: "string"},
 			{Name: "logs_agent_trusted_profile", Value: terraform.Output(t, existingTerraformOptions, "trusted_profile_id"), DataType: "string"},
 			{Name: "cloud_logs_ingress_endpoint", Value: terraform.Output(t, existingTerraformOptions, "cloud_logs_ingress_private_endpoint"), DataType: "string"},
-			{Name: "cluster_resource_group_id", Value: terraform.Output(t, existingTerraformOptions, "cluster_resource_group_id"), DataType: "string"},
+			{Name: "cluster_resource_group_id", Value: terraform.Output(t, existingTerraformOptions, "resource_group_id"), DataType: "string"},
 			{Name: "cloud_monitoring_access_key", Value: terraform.Output(t, existingTerraformOptions, "cloud_monitoring_access_key"), DataType: "string", Secure: true},
 			{Name: "prefix", Value: options.Prefix, DataType: "string"},
 		}

--- a/tests/resources/README.md
+++ b/tests/resources/README.md
@@ -1,4 +1,4 @@
 The terraform code in this directory is used by the tests to provision the following resources:
 
-- A VPC landing zone OCP pattern
-- Observability instances: Log Analysis and Cloud Monitoring
+- A VPC and OCP cluster
+- Observability instances: Cloud Logs and Cloud Monitoring

--- a/tests/resources/main.tf
+++ b/tests/resources/main.tf
@@ -183,5 +183,4 @@ module "ocp_base" {
   vpc_id                              = ibm_is_vpc.vpc.id
   vpc_subnets                         = local.cluster_vpc_subnets
   worker_pools                        = local.worker_pools
-  disable_outbound_traffic_protection = true # set as True to enable outbound traffic; required for accessing Operator Hub in the OpenShift console.
 }

--- a/tests/resources/main.tf
+++ b/tests/resources/main.tf
@@ -11,20 +11,30 @@ module "resource_group" {
 }
 
 ##############################################################################
-# SLZ ROKS Pattern
+# VPC + Subnet + Public Gateway
 ##############################################################################
 
-module "landing_zone" {
-  source                              = "git::https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone//patterns//roks//module?ref=v7.4.4"
-  region                              = var.region
-  prefix                              = var.prefix
-  tags                                = var.resource_tags
-  add_atracker_route                  = false
-  enable_transit_gateway              = false
-  cluster_force_delete_storage        = true
-  verify_cluster_network_readiness    = false
-  use_ibm_cloud_private_api_endpoints = false
-  ignore_vpcs_for_cluster_deployment  = ["management"]
+resource "ibm_is_vpc" "vpc" {
+  name                      = "${var.prefix}-vpc"
+  resource_group            = module.resource_group.resource_group_id
+  address_prefix_management = "auto"
+  tags                      = var.resource_tags
+}
+
+resource "ibm_is_public_gateway" "gateway" {
+  name           = "${var.prefix}-gateway-1"
+  vpc            = ibm_is_vpc.vpc.id
+  resource_group = module.resource_group.resource_group_id
+  zone           = "${var.region}-1"
+}
+
+resource "ibm_is_subnet" "subnet_zone_1" {
+  name                     = "${var.prefix}-subnet-1"
+  vpc                      = ibm_is_vpc.vpc.id
+  resource_group           = module.resource_group.resource_group_id
+  zone                     = "${var.region}-1"
+  total_ipv4_address_count = 256
+  public_gateway           = ibm_is_public_gateway.gateway.id
 }
 
 ##############################################################################
@@ -74,15 +84,10 @@ module "buckets" {
 # - Monitoring instance
 ##############################################################################
 
-locals {
-  cluster_resource_group_id = module.landing_zone.cluster_data["${var.prefix}-workload-cluster"].resource_group_id
-  cluster_crn               = module.landing_zone.cluster_data["${var.prefix}-workload-cluster"].crn
-}
-
 module "observability_instances" {
   source                             = "terraform-ibm-modules/observability-instances/ibm"
   version                            = "3.5.0"
-  resource_group_id                  = local.cluster_resource_group_id
+  resource_group_id                  = module.resource_group.resource_group_id
   region                             = var.region
   cloud_monitoring_plan              = "graduated-tier"
   cloud_monitoring_service_endpoints = "public-and-private"
@@ -131,10 +136,52 @@ module "trusted_profile" {
   trusted_profile_links = [{
     cr_type = "ROKS_SA"
     links = [{
-      crn       = local.cluster_crn
+      crn       = module.ocp_base.cluster_crn
       namespace = local.logs_agent_namespace
       name      = local.logs_agent_name
     }]
     }
   ]
+}
+
+##############################################################################
+# OCP VPC cluster (single zone)
+##############################################################################
+
+locals {
+  cluster_vpc_subnets = {
+    default = [
+      {
+        id         = ibm_is_subnet.subnet_zone_1.id
+        cidr_block = ibm_is_subnet.subnet_zone_1.ipv4_cidr_block
+        zone       = ibm_is_subnet.subnet_zone_1.zone
+      }
+    ]
+  }
+
+  worker_pools = [
+    {
+      subnet_prefix    = "default"
+      pool_name        = "default" # ibm_container_vpc_cluster automatically names default pool "default" (See https://github.com/IBM-Cloud/terraform-provider-ibm/issues/2849)
+      machine_type     = "bx2.4x16"
+      workers_per_zone = 2 # minimum of 2 is allowed when using single zone
+      operating_system = "REDHAT_8_64"
+    }
+  ]
+}
+
+module "ocp_base" {
+  source                              = "terraform-ibm-modules/base-ocp-vpc/ibm"
+  version                             = "3.46.1"
+  resource_group_id                   = module.resource_group.resource_group_id
+  region                              = var.region
+  tags                                = var.resource_tags
+  cluster_name                        = var.prefix
+  force_delete_storage                = true
+  use_existing_cos                    = true
+  existing_cos_id                     = module.cos.cos_instance_id
+  vpc_id                              = ibm_is_vpc.vpc.id
+  vpc_subnets                         = local.cluster_vpc_subnets
+  worker_pools                        = local.worker_pools
+  disable_outbound_traffic_protection = true # set as True to enable outbound traffic; required for accessing Operator Hub in the OpenShift console.
 }

--- a/tests/resources/main.tf
+++ b/tests/resources/main.tf
@@ -171,16 +171,16 @@ locals {
 }
 
 module "ocp_base" {
-  source                              = "terraform-ibm-modules/base-ocp-vpc/ibm"
-  version                             = "3.46.1"
-  resource_group_id                   = module.resource_group.resource_group_id
-  region                              = var.region
-  tags                                = var.resource_tags
-  cluster_name                        = var.prefix
-  force_delete_storage                = true
-  use_existing_cos                    = true
-  existing_cos_id                     = module.cos.cos_instance_id
-  vpc_id                              = ibm_is_vpc.vpc.id
-  vpc_subnets                         = local.cluster_vpc_subnets
-  worker_pools                        = local.worker_pools
+  source               = "terraform-ibm-modules/base-ocp-vpc/ibm"
+  version              = "3.46.1"
+  resource_group_id    = module.resource_group.resource_group_id
+  region               = var.region
+  tags                 = var.resource_tags
+  cluster_name         = var.prefix
+  force_delete_storage = true
+  use_existing_cos     = true
+  existing_cos_id      = module.cos.cos_instance_id
+  vpc_id               = ibm_is_vpc.vpc.id
+  vpc_subnets          = local.cluster_vpc_subnets
+  worker_pools         = local.worker_pools
 }

--- a/tests/resources/outputs.tf
+++ b/tests/resources/outputs.tf
@@ -3,13 +3,13 @@
 ##############################################################################
 
 output "prefix" {
-  value       = module.landing_zone.prefix
+  value       = var.prefix
   description = "prefix"
 }
 
 output "region" {
   value       = var.region
-  description = "Region where SLZ ROKS Cluster is deployed."
+  description = "Region where OCP Cluster is deployed."
 }
 
 output "cluster_id" {

--- a/tests/resources/outputs.tf
+++ b/tests/resources/outputs.tf
@@ -12,24 +12,14 @@ output "region" {
   description = "Region where SLZ ROKS Cluster is deployed."
 }
 
-output "cluster_data" {
-  value       = module.landing_zone.cluster_data
-  description = "Details of OCP cluster."
+output "cluster_id" {
+  value       = module.ocp_base.cluster_id
+  description = "ID of the cluster."
 }
 
-output "workload_cluster_id" {
-  value       = module.landing_zone.workload_cluster_id
-  description = "ID of the workload cluster."
-}
-
-output "workload_cluster_crn" {
-  value       = local.cluster_crn
-  description = "CRN of the workload cluster."
-}
-
-output "cluster_resource_group_id" {
-  value       = local.cluster_resource_group_id
-  description = "Resource group ID of the workload cluster."
+output "resource_group_id" {
+  value       = module.resource_group.resource_group_id
+  description = "Resource group ID"
 }
 
 output "cloud_monitoring_name" {

--- a/tests/scripts/post-validation-destroy-ocp-and-obs-instances.sh
+++ b/tests/scripts/post-validation-destroy-ocp-and-obs-instances.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 ########################################################################################################################
-## This script is used by the catalog pipeline to destroy the SLZ OCP Cluster, which was provisioned as a            ##
-## prerequisite for the WAS extension that is published to the catalog                                                ##
+## This script is used by the catalog pipeline to destroy the OCP Cluster, which was provisioned as a                 ##
+## prerequisite for the Observability agentss DA that is published to the catalog                                     ##
 ########################################################################################################################
 
 set -e
@@ -12,7 +12,7 @@ TF_VARS_FILE="terraform.tfvars"
 
 (
   cd ${TERRAFORM_SOURCE_DIR}
-  echo "Destroying prerequisite SLZ OCP Cluster and Observability instances .."
+  echo "Destroying prerequisite OCP Cluster and Observability instances .."
   terraform destroy -input=false -auto-approve -var-file=${TF_VARS_FILE} || exit 1
   rm -f "${TF_VARS_FILE}"
 

--- a/tests/scripts/pre-validation-deploy-ocp-and-obs-instances.sh
+++ b/tests/scripts/pre-validation-deploy-ocp-and-obs-instances.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 ############################################################################################################
-## This script is used by the catalog pipeline to deploy the SLZ ROKS and Observability instances,
-## which are the prerequisites for the Observability Agents extension.
+## This script is used by the catalog pipeline to deploy the OCP cluster and Observability instances,
+## which are the prerequisites for the Observability Agents DA.
 ############################################################################################################
 
 set -e
@@ -16,7 +16,7 @@ TF_VARS_FILE="terraform.tfvars"
 (
   cwd=$(pwd)
   cd ${TERRAFORM_SOURCE_DIR}
-  echo "Provisioning prerequisite SLZ ROKS CLUSTER and Observability Instances .."
+  echo "Provisioning prerequisite OCP CLUSTER and Observability instances .."
   terraform init || exit 1
   # $VALIDATION_APIKEY is available in the catalog runtime
   {
@@ -28,9 +28,9 @@ TF_VARS_FILE="terraform.tfvars"
 
   region_var_name="region"
   cluster_id_var_name="cluster_id"
-  cluster_id_value=$(terraform output -state=terraform.tfstate -raw workload_cluster_id)
+  cluster_id_value=$(terraform output -state=terraform.tfstate -raw cluster_id)
   cluster_resource_group_id_var_name="cluster_resource_group_id"
-  cluster_resource_group_id_value=$(terraform output -state=terraform.tfstate -raw cluster_resource_group_id)
+  cluster_resource_group_id_value=$(terraform output -state=terraform.tfstate -raw resource_group_id)
   cloud_monitoring_instance_region_var_name="cloud_monitoring_instance_region"
   cloud_monitoring_access_key_var_name="cloud_monitoring_access_key"
   cloud_monitoring_access_key_value=$(terraform output -state=terraform.tfstate -raw cloud_monitoring_access_key)


### PR DESCRIPTION
### Description

Updated agent tests to use cluster with public endpoint enabled so the verify network script can run. This is a workaround for an intermittent catalog validation issue where it tries to connect to cluster before RBAC sync has occurred (more info in internal [issue](https://github.ibm.com/GoldenEye/issues/issues/13241))

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
