### PR TITLE
fix: remove unnecessary metrics_router_settings updates

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -110,6 +110,10 @@
               "hidden": true
             },
             {
+              "key": "use_private_endpoint",
+              "hidden": true
+            },
+            {
               "key": "prefix",
               "required": true
             },

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -73,16 +73,7 @@ locals {
 
   # Get the current primary metadata region if it exists
   # This prevents unnecessary updates when metrics_router_settings is not provided
-  get_existing_primary_metadata_region = var.enable_metrics_routing_to_cloud_monitoring && var.metrics_router_settings == null
-
-  # Only set primary_metadata_region if it's not already configured
-  metrics_router_settings = local.get_existing_primary_metadata_region ? {
-    permitted_target_regions  = []
-    primary_metadata_region   = length(module.get_primary_metadata_region[0].primary_metadata_region) != 0 ? null : var.region
-    backup_metadata_region    = null
-    private_api_endpoint_only = false
-    default_targets           = []
-  } : var.metrics_router_settings
+  has_primary_metadata_region = length(module.get_primary_metadata_region.primary_metadata_region) > 0
 
   archive_bucket_config = var.manage_log_archive_cos_bucket ? {
     class = var.log_archive_cos_bucket_class
@@ -310,7 +301,6 @@ module "cloud_logs" {
 }
 
 module "get_primary_metadata_region" {
-  count                = local.get_existing_primary_metadata_region ? 1 : 0
   source               = "terraform-ibm-modules/cloud-monitoring/ibm//modules/get_primary_metadata_region"
   version              = "1.15.4"
   use_private_endpoint = var.use_private_endpoint
@@ -329,7 +319,13 @@ module "metrics_router" {
     }
   ] : []
   metrics_router_routes   = var.enable_metrics_routing_to_cloud_monitoring ? (length(var.metrics_router_routes) != 0 ? var.metrics_router_routes : local.default_metrics_router_route) : []
-  metrics_router_settings = var.enable_metrics_routing_to_cloud_monitoring ? local.metrics_router_settings : null
+  metrics_router_settings = !var.enable_metrics_routing_to_cloud_monitoring ? null : var.metrics_router_settings != null ? var.metrics_router_settings : local.has_primary_metadata_region ? null : {
+    primary_metadata_region   = var.region
+    backup_metadata_region    = null
+    permitted_target_regions  = []
+    private_api_endpoint_only = false
+    default_targets           = []
+  }
 }
 
 module "activity_tracker" {

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -309,12 +309,11 @@ module "cloud_logs" {
   policies                      = var.cloud_logs_policies
 }
 
-# Get the current primary metadata region to avoid unnecessary updates
 module "get_primary_metadata_region" {
   count                = local.get_existing_primary_metadata_region ? 1 : 0
   source               = "terraform-ibm-modules/cloud-monitoring/ibm//modules/get_primary_metadata_region"
   version              = "1.15.4"
-  use_private_endpoint = var.provider_visibility == "private" ? true : false
+  use_private_endpoint = var.use_private_endpoint
 }
 
 module "metrics_router" {

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -75,7 +75,7 @@ locals {
   # This prevents unnecessary updates when metrics_router_settings is not provided
   has_primary_metadata_region = length(module.get_primary_metadata_region.primary_metadata_region) > 0
 
-  # Default metrics router settings to use when user doesn't provide settings and region is not yet configured
+  # Default metrics router settings to use when user doesn't provide settings and 'primary_metadata_region' is not yet configured
   default_metrics_router_settings = {
     primary_metadata_region   = var.region
     backup_metadata_region    = null

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -70,13 +70,19 @@ locals {
     }]
   }] : []
 
-  metrics_router_settings = {
-    default_targets           = []
-    primary_metadata_region   = var.region
-    backup_metadata_region    = null
+
+  # Get the current primary metadata region if it exists
+  # This prevents unnecessary updates when metrics_router_settings is not provided
+  get_existing_primary_metadata_region = var.enable_metrics_routing_to_cloud_monitoring && var.metrics_router_settings == null
+
+  # Only set primary_metadata_region if it's not already configured
+  metrics_router_settings = var.enable_metrics_routing_to_cloud_monitoring && var.metrics_router_settings == null ? {
     permitted_target_regions  = []
+    primary_metadata_region   = module.get_primary_metadata_region[0].primary_metadata_region != null ? null : var.region
+    backup_metadata_region    = null
     private_api_endpoint_only = false
-  }
+    default_targets           = []
+  } : var.metrics_router_settings
 
   archive_bucket_config = var.manage_log_archive_cos_bucket ? {
     class = var.log_archive_cos_bucket_class
@@ -303,9 +309,17 @@ module "cloud_logs" {
   policies                      = var.cloud_logs_policies
 }
 
-module "metrics_router" {
-  source  = "terraform-ibm-modules/cloud-monitoring/ibm//modules/metrics_routing"
+# Get the current primary metadata region to avoid unnecessary updates
+module "get_primary_metadata_region" {
+  count   = local.get_existing_primary_metadata_region ? 1 : 0
+  source  = "terraform-ibm-modules/cloud-monitoring/ibm//modules/get_primary_metadata_region"
   version = "1.15.4"
+}
+
+module "metrics_router" {
+  depends_on = [module.get_primary_metadata_region]
+  source     = "terraform-ibm-modules/cloud-monitoring/ibm//modules/metrics_routing"
+  version    = "1.15.4"
   metrics_router_targets = var.enable_metrics_routing_to_cloud_monitoring ? [
     {
       destination_crn                 = var.cloud_monitoring_provision ? module.cloud_monitoring[0].crn : var.existing_cloud_monitoring_crn
@@ -315,7 +329,7 @@ module "metrics_router" {
     }
   ] : []
   metrics_router_routes   = var.enable_metrics_routing_to_cloud_monitoring ? (length(var.metrics_router_routes) != 0 ? var.metrics_router_routes : local.default_metrics_router_route) : []
-  metrics_router_settings = var.enable_metrics_routing_to_cloud_monitoring ? (var.metrics_router_settings != null ? var.metrics_router_settings : local.metrics_router_settings) : null
+  metrics_router_settings = var.enable_metrics_routing_to_cloud_monitoring ? local.metrics_router_settings : null
 }
 
 module "activity_tracker" {

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -76,9 +76,9 @@ locals {
   get_existing_primary_metadata_region = var.enable_metrics_routing_to_cloud_monitoring && var.metrics_router_settings == null
 
   # Only set primary_metadata_region if it's not already configured
-  metrics_router_settings = var.enable_metrics_routing_to_cloud_monitoring && var.metrics_router_settings == null ? {
+  metrics_router_settings = local.get_existing_primary_metadata_region ? {
     permitted_target_regions  = []
-    primary_metadata_region   = module.get_primary_metadata_region[0].primary_metadata_region != null ? null : var.region
+    primary_metadata_region   = length(module.get_primary_metadata_region[0].primary_metadata_region) != 0 ? null : var.region
     backup_metadata_region    = null
     private_api_endpoint_only = false
     default_targets           = []
@@ -311,9 +311,10 @@ module "cloud_logs" {
 
 # Get the current primary metadata region to avoid unnecessary updates
 module "get_primary_metadata_region" {
-  count   = local.get_existing_primary_metadata_region ? 1 : 0
-  source  = "terraform-ibm-modules/cloud-monitoring/ibm//modules/get_primary_metadata_region"
-  version = "1.15.4"
+  count                = local.get_existing_primary_metadata_region ? 1 : 0
+  source               = "terraform-ibm-modules/cloud-monitoring/ibm//modules/get_primary_metadata_region"
+  version              = "1.15.4"
+  use_private_endpoint = var.provider_visibility == "private" ? true : false
 }
 
 module "metrics_router" {

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -75,6 +75,15 @@ locals {
   # This prevents unnecessary updates when metrics_router_settings is not provided
   has_primary_metadata_region = length(module.get_primary_metadata_region.primary_metadata_region) > 0
 
+  # Default metrics router settings to use when user doesn't provide settings and region is not yet configured
+  default_metrics_router_settings = {
+    primary_metadata_region   = var.region
+    backup_metadata_region    = null
+    permitted_target_regions  = []
+    private_api_endpoint_only = false
+    default_targets           = []
+  }
+
   archive_bucket_config = var.manage_log_archive_cos_bucket ? {
     class = var.log_archive_cos_bucket_class
     name  = local.log_archive_cos_bucket_name
@@ -319,13 +328,7 @@ module "metrics_router" {
     }
   ] : []
   metrics_router_routes   = var.enable_metrics_routing_to_cloud_monitoring ? (length(var.metrics_router_routes) != 0 ? var.metrics_router_routes : local.default_metrics_router_route) : []
-  metrics_router_settings = !var.enable_metrics_routing_to_cloud_monitoring ? null : var.metrics_router_settings != null ? var.metrics_router_settings : local.has_primary_metadata_region ? null : {
-    primary_metadata_region   = var.region
-    backup_metadata_region    = null
-    permitted_target_regions  = []
-    private_api_endpoint_only = false
-    default_targets           = []
-  }
+  metrics_router_settings = !var.enable_metrics_routing_to_cloud_monitoring ? null : var.metrics_router_settings != null ? var.metrics_router_settings : local.has_primary_metadata_region ? null : local.default_metrics_router_settings
 }
 
 module "activity_tracker" {

--- a/solutions/instances/variables.tf
+++ b/solutions/instances/variables.tf
@@ -62,7 +62,7 @@ variable "provider_visibility" {
   }
 }
 variable "use_private_endpoint" {
-  description = "Set to true to use private endpoints for the metrics router API calls."
+  description = "Set to true to use the private endpoints instead of public endpoints for IBM Cloud Metrics Routing service. When true, the script queries the private Metrics Routing endpoint. [Learn more](https://cloud.ibm.com/docs/metrics-router?topic=metrics-router-endpoints)"
   type        = bool
   default     = false
 }

--- a/solutions/instances/variables.tf
+++ b/solutions/instances/variables.tf
@@ -64,7 +64,7 @@ variable "provider_visibility" {
 variable "use_private_endpoint" {
   description = "Set to true to use the private endpoints instead of public endpoints for IBM Cloud Metrics Routing service. When true, the script queries the private Metrics Routing endpoint. [Learn more](https://cloud.ibm.com/docs/metrics-router?topic=metrics-router-endpoints)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 

--- a/solutions/instances/variables.tf
+++ b/solutions/instances/variables.tf
@@ -61,6 +61,12 @@ variable "provider_visibility" {
     error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
   }
 }
+variable "use_private_endpoint" {
+  description = "Set to true to use private endpoints for the metrics router API calls."
+  type        = bool
+  default     = false
+}
+
 
 ##############################################################################
 # IBM Cloud Logs


### PR DESCRIPTION
### Description

This PR removes the metrics_router_settings updates that occurred on every Terraform run, even when users didn't provide any value for this parameter.

The DA had a fallback logic in solutions/instances/main.tf (lines 73-79) that always set primary_metadata_region = var.region when var.metrics_router_settings was null. This caused Terraform to detect changes on every run.

**Solution:**
With the release of [terraform-ibm-cloud-monitoring PR #127](https://github.com/terraform-ibm-modules/terraform-ibm-cloud-monitoring/pull/127) (included in v1.15.4), the modules/get_primary_metadata_region submodule now handles null settings by checking if primary_metadata_region is already set in IBM Cloud.

- Checks IBM Cloud for existing primary_metadata_region configuration via the `get_primary_metadata_region` module
- Only sets the region if it's currently empty (first deployment)
- Passes null if already configured (subsequent runs)

**Changes:**

- Added `use_private_endpoint` variable to control API endpoint visibility for metrics router queries
- Added `get_primary_metadata_region` module call to check existing settings in IBM Cloud
- Simplified local variable to `has_primary_metadata_region` for checking if settings exist
- Updated `metrics_router_settings` parameter with nested ternary logic that includes all optional fields to maintain type consistency
- The module now correctly handles null values without forcing updates

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->
Issue: [#597](https://github.com/terraform-ibm-modules/terraform-ibm-observability-da/issues/597) – Terraform was updating metrics router settings on every apply when metrics_router_settings was not provided.

**Fix:** 
- Added `get_primary_metadata_region` module to check if metrics router settings already exist in IBM Cloud
- Added `use_private_endpoint` variable for API endpoint control
- Settings are now only set on first deployment; subsequent runs pass null when settings already exist

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
